### PR TITLE
ttyHTIF support for MACHINE=riscv

### DIFF
--- a/meta-riscv/conf/machine/riscv.conf
+++ b/meta-riscv/conf/machine/riscv.conf
@@ -13,7 +13,7 @@ KERNEL_IMAGE_STRIP_EXTRA_SECTIONS  = ".comment"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-riscv"
 
-SERIAL_CONSOLE = "115200 ttyS0"
+SERIAL_CONSOLE = "38400 ttyHTIF0"
 USE_VT ?= "0"
 
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules"

--- a/meta-riscv/recipes-core/sysvinit/sysvinit-inittab_2.88dsf.bbappend
+++ b/meta-riscv/recipes-core/sysvinit/sysvinit-inittab_2.88dsf.bbappend
@@ -1,0 +1,38 @@
+### Fix ttyHTIFN handling
+
+do_install() {
+	install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/inittab ${D}${sysconfdir}/inittab
+
+    tmp="${SERIAL_CONSOLES}"
+    for i in $tmp
+    do
+	j=`echo ${i} | sed s/\;/\ /g`
+	label=`echo ${i} | sed -e 's/^.*;tty//' -e 's/;.*//'`
+    # handle HTIFN names for RISC-V, will be named HN due to 4 char limit
+    if [[ $label == HTIF* ]]; then
+        label=${label:0:1}${label:4}
+    fi
+	echo "$label:12345:respawn:${base_sbindir}/getty ${j}" >> ${D}${sysconfdir}/inittab
+    done
+
+    if [ "${USE_VT}" = "1" ]; then
+        cat <<EOF >>${D}${sysconfdir}/inittab
+# ${base_sbindir}/getty invocations for the runlevels.
+#
+# The "id" field MUST be the same as the last
+# characters of the device (after "tty").
+#
+# Format:
+#  <id>:<runlevels>:<action>:<process>
+#
+
+EOF
+
+        for n in ${SYSVINIT_ENABLED_GETTYS}
+        do
+            echo "$n:2345:respawn:${base_sbindir}/getty 38400 tty$n" >> ${D}${sysconfdir}/inittab
+        done
+        echo "" >> ${D}${sysconfdir}/inittab
+    fi
+}


### PR DESCRIPTION
Allows setting serial console to "ttyHTIFN". The standard sysvinit-inittab recipe was creating a label of "HTIFN", which is too long (4 char max). This instead uses "HN" if the name starts with "HTIF".
