### PR TITLE
riscv-pk: install bbl to native sysroot

### DIFF
--- a/meta-riscv/recipes-devtools/riscv-tools/riscv-pk.bb
+++ b/meta-riscv/recipes-devtools/riscv-tools/riscv-pk.bb
@@ -13,6 +13,7 @@ SRC_URI += "file://bbl"
 inherit autotools
 
 DEPENDS = "riscv-fesvr-native riscv-spike-native"
+DEPENDS_append_class-target = " ${PN}-native"
 
 S = "${WORKDIR}/git"
 
@@ -26,3 +27,20 @@ do_configure_prepend () {
                 cp ${S}/aclocal.m4 ${S}/acinclude.m4
         fi
 }
+
+do_compile_class-native () {
+        :
+}
+
+do_install_class-native () {
+        install -d ${D}/${datadir}/riscv-pk
+        install -m 755 ${WORKDIR}/bbl ${D}/${datadir}/riscv-pk
+}
+
+PROVIDES_${PN}_class-native += "${PN}-bbl"
+PACKAGES_class-native += " ${PN}-bbl"
+
+FILES_${PN}-bbl += "${datadir}/riscv-pk"
+FILES_${PN}-bbl-dbg += "${datadir}/riscv-pk/.debug"
+
+BBCLASSEXTEND = "native"

--- a/scripts/runspike
+++ b/scripts/runspike
@@ -382,7 +382,7 @@ echo "FSTYPE: [$FSTYPE]"
 setup_sysroot
 
 SPIKE_BIN="$OECORE_NATIVE_SYSROOT/usr/bin/spike"
-BBL_PATH="$OE_TMPDIR/work/riscv64-poky-linux/riscv-pk/1.0-r0/bbl"
+BBL_PATH="$OECORE_NATIVE_SYSROOT/usr/share/riscv-pk/bbl"
 
 echo "SPIKE_BIN: [$SPIKE_BIN]"
 echo "BBL_PATH: [$BBL_PATH]"


### PR DESCRIPTION
Install the bbl file to native sysroot instead of keep it in the
${WORKDIR}, this will let user can use `INHERIT += "rm_work"` in their
conf/local.conf.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>