### PR TITLE
change default YOCTO build to "riscv64" (spike version)

### DIFF
--- a/meta-riscv/conf/local.conf.sample
+++ b/meta-riscv/conf/local.conf.sample
@@ -56,8 +56,12 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 #
 # This sets the default machine to be qemux86 if no other machine is selected:
 
-#MACHINE = "riscv64"
-MACHINE = "qemuriscv64"
+# Quemu build is currently not functional as of  12/1/2015, make the spike version (riscv64) the default
+#MACHINE = "qemuriscv64"
+
+# This is the MACHINE declaration for the spike version for riscv64:
+
+MACHINE = "riscv64"
 
 #
 # Where to place downloads


### PR DESCRIPTION
 
YOCTO build for Qemu is currently not functional as of  12/1/2015, make the spike version (riscv64) the default