### PR TITLE
Optionally include strace in distro

### DIFF
--- a/meta-riscv/recipes-devtools/strace/strace/0001-Add-linux-aarch64-arch_regs.h.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/0001-Add-linux-aarch64-arch_regs.h.patch
@@ -1,0 +1,25 @@
+From f85854131c8265f2eb59c714dcea5c4b3dc09bed Mon Sep 17 00:00:00 2001
+From: Koen Kooi <koen.kooi@linaro.org>
+Date: Wed, 15 Apr 2015 14:29:37 +0200
+Subject: [PATCH] Add linux/aarch64/arch_regs.h
+
+It is missing from the tarball, but it is present in git for v4.10
+
+Signed-off-by: Koen Kooi <koen.kooi@linaro.org>
+Upstream-Status: Pending
+---
+ linux/aarch64/arch_regs.h | 2 ++
+ 1 file changed, 2 insertions(+)
+ create mode 100644 linux/aarch64/arch_regs.h
+
+diff --git a/linux/aarch64/arch_regs.h b/linux/aarch64/arch_regs.h
+new file mode 100644
+index 0000000..9a5e33e
+--- /dev/null
++++ b/linux/aarch64/arch_regs.h
+@@ -0,0 +1,2 @@
++extern uint64_t *const aarch64_sp_ptr;
++extern uint32_t *const arm_sp_ptr;
+-- 
+1.9.3
+

--- a/meta-riscv/recipes-devtools/strace/strace/Include-linux-ioctl.h-for-_IOC_-macros.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/Include-linux-ioctl.h-for-_IOC_-macros.patch
@@ -1,0 +1,69 @@
+Upstream-Status: Backport
+
+  http://sourceforge.net/p/strace/code/ci/3460dc486d333231998de0f19918204aacee9ae3
+
+Expected to be released officially as part of strace 4.11
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+
+From 3460dc486d333231998de0f19918204aacee9ae3 Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Sat, 28 Mar 2015 18:40:13 +0100
+Subject: [PATCH] Include <linux/ioctl.h> for _IOC_* macros
+
+Fix a compilation failure with musl libc.
+
+* evdev.c: Include <linux/ioctl.h>.
+* ioctl.c: Include <linux/ioctl.h> instead of <asm/ioctl.h>.
+* ioctlsort.c: Likewise.
+
+Reported-by: Dima Krasner <dima@dimakrasner.com>
+Acked-by: Mike Frysinger <vapier@gentoo.org>
+---
+ evdev.c     | 2 ++
+ ioctl.c     | 2 +-
+ ioctlsort.c | 2 +-
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/evdev.c b/evdev.c
+index 9a7430d..e06f9c1 100644
+--- a/evdev.c
++++ b/evdev.c
+@@ -28,6 +28,8 @@
+ 
+ #include "defs.h"
+ 
++#include <linux/ioctl.h>
++
+ #ifdef HAVE_LINUX_INPUT_H
+ #include <linux/input.h>
+ #include "xlat/evdev_abs.h"
+diff --git a/ioctl.c b/ioctl.c
+index 46f8334..c67d048 100644
+--- a/ioctl.c
++++ b/ioctl.c
+@@ -29,7 +29,7 @@
+  */
+ 
+ #include "defs.h"
+-#include <asm/ioctl.h>
++#include <linux/ioctl.h>
+ #include "xlat/ioctl_dirs.h"
+ 
+ #ifdef HAVE_LINUX_INPUT_H
+diff --git a/ioctlsort.c b/ioctlsort.c
+index 333556c..9c31691 100644
+--- a/ioctlsort.c
++++ b/ioctlsort.c
+@@ -33,7 +33,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <asm/ioctl.h>
++#include <linux/ioctl.h>
+ 
+ struct ioctlent {
+ 	const char *info;
+-- 
+1.9.1
+

--- a/meta-riscv/recipes-devtools/strace/strace/Include-sys-stat.h-for-S_I-macros.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/Include-sys-stat.h-for-S_I-macros.patch
@@ -1,0 +1,52 @@
+Upstream-Status: Backport
+
+  http://sourceforge.net/p/strace/code/ci/d34e00b293942b1012ddc49ed3ab379a32337611
+
+Expected to be released officially as part of strace 4.11
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+
+From d34e00b293942b1012ddc49ed3ab379a32337611 Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Sat, 28 Mar 2015 18:21:09 +0100
+Subject: [PATCH] Include <sys/stat.h> for S_I* macros
+
+Fix a compilation failure with musl libc.
+
+* mknod.c: Include <sys/stat.h>.
+* printmode.c: Likewise.
+
+Reported-by: Dima Krasner <dima@dimakrasner.com>
+Acked-by: Mike Frysinger <vapier@gentoo.org>
+---
+ mknod.c     | 1 +
+ printmode.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/mknod.c b/mknod.c
+index 07e9a45..1463232 100644
+--- a/mknod.c
++++ b/mknod.c
+@@ -1,6 +1,7 @@
+ #include "defs.h"
+ 
+ #include <fcntl.h>
++#include <sys/stat.h>
+ 
+ #ifdef MAJOR_IN_SYSMACROS
+ # include <sys/sysmacros.h>
+diff --git a/printmode.c b/printmode.c
+index 4df1b9f..a721936 100644
+--- a/printmode.c
++++ b/printmode.c
+@@ -1,6 +1,7 @@
+ #include "defs.h"
+ 
+ #include <fcntl.h>
++#include <sys/stat.h>
+ 
+ #include "xlat/modetypes.h"
+ 
+-- 
+1.9.1
+

--- a/meta-riscv/recipes-devtools/strace/strace/Makefile-ptest.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/Makefile-ptest.patch
@@ -1,0 +1,53 @@
+strace: Add ptest
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Gabriel Barbu <gabriel.barbu@enea.com>
+Signed-off-by: Chong Lu <Chong.Lu@windriver.com>
+---
+ configure.ac      |  2 +-
+ tests/Makefile.am | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index e73958c..5f0dfee 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -6,7 +6,7 @@ AC_INIT([strace],
+ AC_CONFIG_SRCDIR([strace.c])
+ AC_CONFIG_AUX_DIR([.])
+ AC_CONFIG_HEADERS([config.h])
+-AM_INIT_AUTOMAKE([foreign dist-xz no-dist-gzip silent-rules parallel-tests])
++AM_INIT_AUTOMAKE([foreign dist-xz no-dist-gzip silent-rules serial-tests])
+ AM_MAINTAINER_MODE
+ AC_CANONICAL_HOST
+ 
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index ff5e136..984bdb6 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -101,3 +101,21 @@ EXTRA_DIST = init.sh run.sh \
+ 	     $(TESTS)
+ 
+ CLEANFILES = $(TESTS:=.tmp)
++
++buildtest-TESTS: $(check_PROGRAMS) $(TESTS)
++
++install-ptest:
++	install $(BUILDDIR)/strace $(DESTDIR)
++	install "$(srcdir)/.."/strace-log-merge $(DESTDIR)
++	install -d $(DESTDIR)/$(TESTDIR)
++	cp $(BUILDDIR)/$(TESTDIR)/Makefile $(DESTDIR)/$(TESTDIR)
++	sed -i -e 's/^Makefile:/_Makefile:/' $(DESTDIR)/$(TESTDIR)/Makefile
++	sed -i -e 's/bash/sh/' $(DESTDIR)/$(TESTDIR)/Makefile
++	for file in $(check_PROGRAMS); do \
++		install $(BUILDDIR)/$(TESTDIR)/$$file $(DESTDIR)/$(TESTDIR); \
++	done
++	for file in $(EXTRA_DIST); do \
++		install $(srcdir)/$$file $(DESTDIR)/$(TESTDIR); \
++		sed -i -e 's/$${srcdir=.}/./g' $(DESTDIR)/$(TESTDIR)/$$file; \
++	done
++	for i in net net-fd scm_rights-fd sigaction; do sed -i -e 's/$$srcdir/./g' $(DESTDIR)/$(TESTDIR)/$$i.test; done
+-- 
+1.9.1
+

--- a/meta-riscv/recipes-devtools/strace/strace/git-version-gen
+++ b/meta-riscv/recipes-devtools/strace/strace/git-version-gen
@@ -1,0 +1,225 @@
+#!/bin/sh
+# Print a version string.
+scriptversion=2012-12-31.23; # UTC
+
+# Copyright (C) 2007-2013 Free Software Foundation, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script is derived from GIT-VERSION-GEN from GIT: http://git.or.cz/.
+# It may be run two ways:
+# - from a git repository in which the "git describe" command below
+#   produces useful output (thus requiring at least one signed tag)
+# - from a non-git-repo directory containing a .tarball-version file, which
+#   presumes this script is invoked like "./git-version-gen .tarball-version".
+
+# In order to use intra-version strings in your project, you will need two
+# separate generated version string files:
+#
+# .tarball-version - present only in a distribution tarball, and not in
+#   a checked-out repository.  Created with contents that were learned at
+#   the last time autoconf was run, and used by git-version-gen.  Must not
+#   be present in either $(srcdir) or $(builddir) for git-version-gen to
+#   give accurate answers during normal development with a checked out tree,
+#   but must be present in a tarball when there is no version control system.
+#   Therefore, it cannot be used in any dependencies.  GNUmakefile has
+#   hooks to force a reconfigure at distribution time to get the value
+#   correct, without penalizing normal development with extra reconfigures.
+#
+# .version - present in a checked-out repository and in a distribution
+#   tarball.  Usable in dependencies, particularly for files that don't
+#   want to depend on config.h but do want to track version changes.
+#   Delete this file prior to any autoconf run where you want to rebuild
+#   files to pick up a version string change; and leave it stale to
+#   minimize rebuild time after unrelated changes to configure sources.
+#
+# As with any generated file in a VC'd directory, you should add
+# /.version to .gitignore, so that you don't accidentally commit it.
+# .tarball-version is never generated in a VC'd directory, so needn't
+# be listed there.
+#
+# Use the following line in your configure.ac, so that $(VERSION) will
+# automatically be up-to-date each time configure is run (and note that
+# since configure.ac no longer includes a version string, Makefile rules
+# should not depend on configure.ac for version updates).
+#
+# AC_INIT([GNU project],
+#         m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+#         [bug-project@example])
+#
+# Then use the following lines in your Makefile.am, so that .version
+# will be present for dependencies, and so that .version and
+# .tarball-version will exist in distribution tarballs.
+#
+# EXTRA_DIST = $(top_srcdir)/.version
+# BUILT_SOURCES = $(top_srcdir)/.version
+# $(top_srcdir)/.version:
+#	echo $(VERSION) > $@-t && mv $@-t $@
+# dist-hook:
+#	echo $(VERSION) > $(distdir)/.tarball-version
+
+
+me=$0
+
+version="git-version-gen $scriptversion
+
+Copyright 2011 Free Software Foundation, Inc.
+There is NO warranty.  You may redistribute this software
+under the terms of the GNU General Public License.
+For more information about these matters, see the files named COPYING."
+
+usage="\
+Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Print a version string.
+
+Options:
+
+   --prefix           prefix of git tags (default 'v')
+   --fallback         fallback version to use if \"git --version\" fails
+
+   --help             display this help and exit
+   --version          output version information and exit
+
+Running without arguments will suffice in most cases."
+
+prefix=v
+fallback=
+
+while test $# -gt 0; do
+  case $1 in
+    --help) echo "$usage"; exit 0;;
+    --version) echo "$version"; exit 0;;
+    --prefix) shift; prefix="$1";;
+    --fallback) shift; fallback="$1";;
+    -*)
+      echo "$0: Unknown option '$1'." >&2
+      echo "$0: Try '--help' for more information." >&2
+      exit 1;;
+    *)
+      if test "x$tarball_version_file" = x; then
+        tarball_version_file="$1"
+      elif test "x$tag_sed_script" = x; then
+        tag_sed_script="$1"
+      else
+        echo "$0: extra non-option argument '$1'." >&2
+        exit 1
+      fi;;
+  esac
+  shift
+done
+
+if test "x$tarball_version_file" = x; then
+    echo "$usage"
+    exit 1
+fi
+
+tag_sed_script="${tag_sed_script:-s/x/x/}"
+
+nl='
+'
+
+# Avoid meddling by environment variable of the same name.
+v=
+v_from_git=
+
+# First see if there is a tarball-only version file.
+# then try "git describe", then default.
+if test -f $tarball_version_file
+then
+    v=`cat $tarball_version_file` || v=
+    case $v in
+        *$nl*) v= ;; # reject multi-line output
+        [0-9]*) ;;
+        *) v= ;;
+    esac
+    test "x$v" = x \
+        && echo "$0: WARNING: $tarball_version_file is missing or damaged" 1>&2
+fi
+
+if test "x$v" != x
+then
+    : # use $v
+# Otherwise, if there is at least one git commit involving the working
+# directory, and "git describe" output looks sensible, use that to
+# derive a version string.
+elif test "`git log -1 --pretty=format:x . 2>&1`" = x \
+    && v=`git describe --abbrev=4 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --abbrev=4 HEAD 2>/dev/null` \
+    && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
+    && case $v in
+         $prefix[0-9]*) ;;
+         *) (exit 1) ;;
+       esac
+then
+    # Is this a new git that lists number of commits since the last
+    # tag or the previous older version that did not?
+    #   Newer: v6.10-77-g0f8faeb
+    #   Older: v6.10-g0f8faeb
+    case $v in
+        *-*-*) : git describe is okay three part flavor ;;
+        *-*)
+            : git describe is older two part flavor
+            # Recreate the number of commits and rewrite such that the
+            # result is the same as if we were using the newer version
+            # of git describe.
+            vtag=`echo "$v" | sed 's/-.*//'`
+            commit_list=`git rev-list "$vtag"..HEAD 2>/dev/null` \
+                || { commit_list=failed;
+                     echo "$0: WARNING: git rev-list failed" 1>&2; }
+            numcommits=`echo "$commit_list" | wc -l`
+            v=`echo "$v" | sed "s/\(.*\)-\(.*\)/\1-$numcommits-\2/"`;
+            test "$commit_list" = failed && v=UNKNOWN
+            ;;
+    esac
+
+    # Change the first '-' to a '.', so version-comparing tools work properly.
+    # Remove the "g" in git describe's output string, to save a byte.
+    v=`echo "$v" | sed 's/-/.0./;s/\(.*\)-g/\1-/'`;
+    v_from_git=1
+elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
+    v=UNKNOWN
+else
+    v=$fallback
+fi
+
+v=`echo "$v" |sed "s/^$prefix//"`
+
+# Test whether to append the "-dirty" suffix only if the version
+# string we're using came from git.  I.e., skip the test if it's "UNKNOWN"
+# or if it came from .tarball-version.
+if test "x$v_from_git" != x; then
+  # Don't declare a version "dirty" merely because a time stamp has changed.
+  git update-index --refresh > /dev/null 2>&1
+
+  dirty=`exec 2>/dev/null;git diff-index --name-only HEAD` || dirty=
+  case "$dirty" in
+      '') ;;
+      *) # Append the suffix only if there isn't one already.
+          case $v in
+            *-dirty) ;;
+            *) v="$v-dirty" ;;
+          esac ;;
+  esac
+fi
+
+# Omit the trailing newline, so that m4_esyscmd can use the result directly.
+echo "$v" | tr -d "$nl"
+
+# Local variables:
+# eval: (add-hook 'write-file-hooks 'time-stamp)
+# time-stamp-start: "scriptversion="
+# time-stamp-format: "%:y-%02m-%02d.%02H"
+# time-stamp-time-zone: "UTC"
+# time-stamp-end: "; # UTC"
+# End:

--- a/meta-riscv/recipes-devtools/strace/strace/no-git-version.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/no-git-version.patch
@@ -1,0 +1,11 @@
+diff -Naur riscv-strace/configure.ac new-strace/configure.ac
+--- riscv-strace/configure.ac	2016-02-26 18:33:48.263437007 -0800
++++ new-strace/configure.ac	2016-02-26 18:34:44.351888843 -0800
+@@ -1,7 +1,6 @@
+ dnl Process this file with autoconf to create configure.  Use autoreconf.
+ AC_PREREQ(2.57)
+ AC_INIT([strace],
+-	m4_esyscmd([./git-version-gen .tarball-version]),
+ 	[strace-devel@lists.sourceforge.net])
+ AC_CONFIG_SRCDIR([strace.c])
+ AC_CONFIG_AUX_DIR([.])

--- a/meta-riscv/recipes-devtools/strace/strace/run-ptest
+++ b/meta-riscv/recipes-devtools/strace/strace/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -C tests -k runtest-TESTS

--- a/meta-riscv/recipes-devtools/strace/strace/strace-add-configure-options.patch
+++ b/meta-riscv/recipes-devtools/strace/strace/strace-add-configure-options.patch
@@ -1,0 +1,57 @@
+Add options "aio" and "acl" to enable/disable libaio and acl support.
+
+Upstream-Status: Pending
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+Signed-off-by: Chong Lu <Chong.Lu@windriver.com>
+---
+ configure.ac |   26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index e73958c..9099370 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -270,6 +270,18 @@ AC_CHECK_HEADERS(m4_normalize([
+ 	sys/vfs.h
+ 	sys/xattr.h
+ ]))
++
++AC_ARG_ENABLE([acl],
++	[AS_HELP_STRING([--enable-acl], [turn on acl support])],
++	[case $enableval in
++	yes)
++		AC_CHECK_HEADERS([sys/acl.h])
++		;;
++	no)  ;;
++	*)   AC_MSG_ERROR([bad value $enableval for aio option]) ;;
++	esac]
++)
++
+ AC_CHECK_HEADERS([linux/icmp.h linux/in6.h linux/netlink.h linux/if_packet.h],
+                  [], [], [#include <stddef.h>
+ #include <sys/socket.h>
+@@ -745,6 +757,20 @@ if test "x$ac_cv_lib_dl_dladdr" = xyes; then
+ fi
+ AC_SUBST(dl_LIBS)
+ 
++AC_ARG_ENABLE([aio],
++	[AS_HELP_STRING([--enable-aio], [turn on libaio support])],
++	[case $enableval in
++	yes)
++	AC_CHECK_HEADERS([libaio.h], [
++		AC_CHECK_MEMBERS([struct iocb.u.c.flags],,, [#include <libaio.h>])
++		AC_CHECK_DECLS([IO_CMD_PWRITE, IO_CMD_PWRITEV],,, [#include <libaio.h>])
++	])
++	;;
++	no)  ;;
++	*)   AC_MSG_ERROR([bad value $enableval for aio option]) ;;
++	esac]
++)
++
+ AC_PATH_PROG([PERL], [perl])
+ 
+ dnl stack trace with libunwind
+--
+1.9.1
+

--- a/meta-riscv/recipes-devtools/strace/strace_4.9.bb
+++ b/meta-riscv/recipes-devtools/strace/strace_4.9.bb
@@ -1,0 +1,44 @@
+SUMMARY = "System call tracing tool"
+HOMEPAGE = "http://strace.sourceforge.net"
+SECTION = "console/utils"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=124500c21e856f0912df29295ba104c7"
+
+SRC_URI = "git://github.com/riscv/riscv-strace.git;branch=riscv-4.9 \
+          file://no-git-version.patch \
+          "
+SRCREV = "f320e1897832fd07a62e18ed288e75d8e79f4c5b"
+SRC_URI[md5sum] = "d49ccd4a40254552ad369de4601d4575"
+SRC_URI[sha256sum] = "23fcb421dbb14ad6988d06d0e0eb4af48e2fc46482cc416df4a8a63c96fd2b32"
+
+inherit autotools
+RDEPENDS_${PN}-ptest += "make coreutils grep gawk"
+
+#PACKAGECONFIG_class-target ??= "\
+#    libaio ${@bb.utils.contains('DISTRO_FEATURES', 'acl', 'acl', '', d)} \
+#    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+#"
+
+#PACKAGECONFIG[libaio] = "--enable-aio,--disable-aio,libaio"
+PACKAGECONFIG[acl] = "--enable-acl,--disable-acl,acl"
+PACKAGECONFIG[libunwind] = "--with-libunwind, --without-libunwind, libunwind"
+#PACKAGECONFIG[bluez] = "ac_cv_header_bluetooth_bluetooth_h=yes,ac_cv_header_bluetooth_bluetooth_h=no,${BLUEZ}"
+
+TESTDIR = "tests"
+
+S = "${WORKDIR}/riscv-strace-riscv-${PV}"
+
+do_install_append() {
+	# We don't ship strace-graph here because it needs perl
+	rm ${D}${bindir}/strace-graph
+}
+
+do_compile_ptest() {
+	oe_runmake -C ${TESTDIR} buildtest-TESTS OS=linux ARCH="${TARGET_ARCH}"
+}
+
+#do_install_ptest() {
+#	oe_runmake -C ${TESTDIR} install-ptest BUILDDIR=${B} DESTDIR=${D}${PTEST_PATH} TESTDIR=${TESTDIR}
+#}
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
It doesn't work yet with the current kernel, so don't include it by default, but at least this is a recipe that compiles.  

I copied the default strace recipe in meta/recipes-devtools/strace and removed the parts that depend on Bluetooth (wtf?) and which rely on the git-version-gen tool to rename files according to the strace version number (this seems unnecessary, and, at any rate, that tool is missing).  Also set to pull sources from Palmer's riscv-strace repo on github.