### PR TITLE
Added recipe for native GDB (still under development)

### DIFF
--- a/meta-riscv/conf/distro/poky-riscv.conf
+++ b/meta-riscv/conf/distro/poky-riscv.conf
@@ -18,6 +18,8 @@ PREFERRED_VERSION_python-riscv := "2.7.3"
 PREFERRED_VERSION_libffi-riscv := "3.1"
 PREFERRED_VERSION_libffi-native := "3.2.1"
 
+PREFERRED_VERSION_gdb := "7.11%"
+
 # Make sure Linux header versions and Linux version fit.
 PREFERRED_VERSION_linux-libc-headers := "${PREFERRED_VERSION_linux-riscv}"
 PREFERRED_VERSION_nativesdk-linux-libc-headers := "${PREFERRED_VERSION_linux-riscv}"

--- a/meta-riscv/recipes-devtools/gdb/gdb-7.11.50.inc
+++ b/meta-riscv/recipes-devtools/gdb/gdb-7.11.50.inc
@@ -1,0 +1,7 @@
+LICENSE = "GPLv2 & GPLv3 & LGPLv2 & LGPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
+                    "
+SRC_URI = "https://github.com/riscv/riscv-binutils-gdb/archive/riscv-rebase-2016.02.11.zip"
+SRC_URI[md5sum] = "6073f700bc86d6fdb32a8fc2140092b3"
+SRC_URI[sha256sum] = "9eba7e02f6b288fc3a8072b96dbbd7420308b854c5b6ff9cf13ed3b3757b5982"
+

--- a/meta-riscv/recipes-devtools/gdb/gdb-common.inc
+++ b/meta-riscv/recipes-devtools/gdb/gdb-common.inc
@@ -1,0 +1,71 @@
+SUMMARY = "GNU debugger"
+HOMEPAGE = "http://www.gnu.org/software/gdb/"
+LICENSE = "GPLv3+"
+SECTION = "devel"
+DEPENDS = "expat zlib ncurses readline"
+
+LTTNGUST = "lttng-ust"
+LTTNGUST_aarch64 = ""
+LTTNGUST_libc-uclibc = ""
+LTTNGUST_mips = ""
+LTTNGUST_mipsel = ""
+LTTNGUST_mips64 = ""
+LTTNGUST_mips64el = ""
+LTTNGUST_mips64n32 = ""
+LTTNGUST_mips64eln32 = ""
+LTTNGUST_sh4 = ""
+LTTNGUST_libc-musl = ""
+
+INC_PR = "r0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
+		file://COPYING.LIB;md5=9f604d8a4f8e74f4f5140845a21b6674 \
+		file://COPYING3;md5=d32239bcb673463ab874e80d47fae504 \
+		file://COPYING3.LIB;md5=6a6a8e020838b23406c81b19c1d46df6"
+inherit autotools texinfo
+
+SRC_URI = "${GNU_MIRROR}/gdb/gdb-${PV}.tar.gz \
+          "
+export CC_FOR_BUILD = "${BUILD_CC}"
+export CXX_FOR_BUILD = "${BUILD_CXX}"
+export CPP_FOR_BUILD = "${BUILD_CPP}"
+export CFLAGS_FOR_BUILD = "${BUILD_CFLAGS}"
+export CXXFLAGS_FOR_BUILD = "${BUILD_CXXFLAGS}"
+export CPPFLAGS_FOR_BUILD = "${BUILD_CPPFLAGS}"
+
+B = "${WORKDIR}/build-${TARGET_SYS}"
+
+EXTRA_OEMAKE = "'SUBDIRS=intl mmalloc libiberty opcodes bfd sim gdb etc utils'"
+
+EXPAT = "--with-expat --with-libexpat-prefix=${STAGING_DIR_HOST}"
+
+EXTRA_OECONF = "--disable-gdbtk --disable-tui --disable-x --disable-werror \
+                --with-curses --disable-multilib --with-system-readline --disable-sim \
+                --without-lzma --without-guile \
+                ${GDBPROPREFIX} ${EXPAT} \
+                ${@bb.utils.contains('DISTRO_FEATURES', 'multiarch', '--enable-64-bit-bfd', '', d)} \
+                --disable-rpath \
+               "
+
+GDBPROPREFIX = "--program-prefix=''"
+
+do_configure () {
+	# override this function to avoid the autoconf/automake/aclocal/autoheader
+	# calls for now
+	(cd ${S} && gnu-configize) || die "failure in running gnu-configize"
+	oe_runconf
+}
+
+# we don't want gdb to provide bfd/iberty/opcodes, which instead will override the
+# right bits installed by binutils.
+do_install_append() {
+	rm -rf ${D}${libdir}
+	rm -rf ${D}${includedir}
+	rm -rf ${D}${datadir}/locale
+}
+
+RRECOMMENDS_gdb_append_linux = " glibc-thread-db "
+RRECOMMENDS_gdb_append_linux-gnueabi = " glibc-thread-db "
+RRECOMMENDS_gdbserver_append_linux = " glibc-thread-db "
+RRECOMMENDS_gdbserver_append_linux-gnueabi = " glibc-thread-db "
+

--- a/meta-riscv/recipes-devtools/gdb/gdb_7.11.50.bb
+++ b/meta-riscv/recipes-devtools/gdb/gdb_7.11.50.bb
@@ -1,0 +1,30 @@
+require gdb.inc
+require gdb-${PV}.inc
+
+inherit python-dir
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[python] = "--with-python=${WORKDIR}/python,--without-python,python,python python-codecs"
+PACKAGECONFIG[babeltrace] = "--with-babeltrace,--without-babeltrace,babeltrace"
+
+S = "${WORKDIR}/riscv-binutils-gdb-riscv-rebase-2016.02.11"
+
+do_configure_prepend() {
+	if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'python', 'python', '', d)}" ]; then
+		cat > ${WORKDIR}/python << EOF
+#!/bin/sh
+case "\$2" in
+	--includes) echo "-I${STAGING_INCDIR}/${PYTHON_DIR}/" ;;
+	--ldflags) echo "-Wl,-rpath-link,${STAGING_LIBDIR}/.. -Wl,-rpath,${libdir}/.. -lpthread -ldl -lutil -lm -lpython${PYTHON_BASEVERSION}" ;;
+	--exec-prefix) echo "${exec_prefix}" ;;
+	*) exit 1 ;;
+esac
+exit 0
+EOF
+		chmod +x ${WORKDIR}/python
+	fi
+}
+
+do_install_prepend() {
+  cd gdb
+}


### PR DESCRIPTION
You can compile it into the image by adding "gdb" it to core-image-riscv.bb, but it's not yet usable in qemu because of some GDB-internal problem, or possibly because of riscv-linux's ptrace support.  I'll work on debugging that, but this recipe is independent of it.

It is, however, still a hack: the recipe acquire's Palmer's fixed-up GDB (https://github.com/riscv/riscv-binutils-gdb/) as part of the larger binutils repo, all of which is downloaded and compiled before GDB itself is extracted and installed.  This isn't ideal, but there is no separate GDB repo.
