### PR TITLE
qemu-native: fix build

### DIFF
--- a/meta-riscv/recipes-devtools/qemu/qemu_2.5.0.bb
+++ b/meta-riscv/recipes-devtools/qemu/qemu_2.5.0.bb
@@ -1,8 +1,8 @@
 require recipes-devtools/qemu/qemu.inc
 
 SRC_URI = "gitsm://github.com/riscv/riscv-qemu.git;destsuffix=${S}"
-SRCREV_pn-qemu-native = "b0cf38d08a4779ec12d7189878b2e57d2b56ec6b"
-SRCREV_pn-nativesdk-qemu = "b0cf38d08a4779ec12d7189878b2e57d2b56ec6b"
+SRCREV_pn-qemu-native = "29ed7690a7c30ef331fe6acdc4de3ff2966ac679"
+SRCREV_pn-nativesdk-qemu = "29ed7690a7c30ef331fe6acdc4de3ff2966ac679"
 
 SRC_URI_remove_class-native = "\
     file://fix-libcap-header-issue-on-some-distro.patch \
@@ -11,7 +11,7 @@ SRC_URI_remove_class-native = "\
 
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac"
 
-QEMU_TARGETS = "riscv"
+QEMU_TARGETS = "riscv64"
 
 EXTRA_OECONF_remove = "--disable-numa --disable-lzo --disable-opengl --disable-gnutls"
 

--- a/meta/recipes-devtools/qemu/qemu-targets.inc
+++ b/meta/recipes-devtools/qemu/qemu-targets.inc
@@ -7,7 +7,7 @@ def get_qemu_target_list(d):
     archs = d.getVar('QEMU_TARGETS', True).split()
     tos = d.getVar('HOST_OS', True)
     softmmuonly = ""
-    for arch in ['ppcemb', 'riscv']:
+    for arch in ['ppcemb', 'riscv64']:
         if arch in archs:
             softmmuonly += arch + "-softmmu,"
             archs.remove(arch)


### PR DESCRIPTION
The risc-v qemu recipe wasn't pointing at a valid commit from the
github.com/riscv/riscv-qemu.git repository.

Tweak how the QEMU_TARGETS variable is populated in order to pick a valid
target. IOW riscv -> riscv64.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>