### PR TITLE
 Priv 1.10 with libffi

### DIFF
--- a/meta-riscv/recipes-core/images/core-image-riscv.bb
+++ b/meta-riscv/recipes-core/images/core-image-riscv.bb
@@ -12,10 +12,10 @@ IMAGE_INSTALL = "packagegroup-core-boot ${ROOTFS_BOOTSTRAP_INSTALL} ${CORE_IMAGE
 IMAGE_INSTALL += "apt libffi libffi-dev"
 
 # Python
-#IMAGE_INSTALL += "python-numpy python-subprocess python-ctypes python-html python-netserver python-compile"
+IMAGE_INSTALL += "python-numpy python-subprocess python-ctypes python-html python-netserver python-compile"
 
 # Basic toolchain on target
-#IMAGE_INSTALL += "gcc binutils glibc glibc-dev libgcc libgcc-dev libstdc++ libstdc++-dev"
+IMAGE_INSTALL += "gcc binutils glibc glibc-dev libgcc libgcc-dev libstdc++ libstdc++-dev"
 
 IMAGE_LINGUAS = " "
 

--- a/meta-riscv/recipes-support/libffi/libffi_3.2.1.bbappend
+++ b/meta-riscv/recipes-support/libffi/libffi_3.2.1.bbappend
@@ -1,0 +1,4 @@
+SRCREV_riscv64 = "f3662d621c0e900881b78f6f8989ddc6fae8b1d7"
+SRC_URI_riscv64 = "\
+     git://github.com/alonamid/libffi-riscv;branch=master;protocol=git \
+"


### PR DESCRIPTION
Add pointer to the current working libffi repo, and turn on the python build in the core image recipe