### PR TITLE
Fixes a problem where gcc has an internal error when compiling C programs with headers

### DIFF
--- a/meta/recipes-devtools/gcc/gcc-7.2.inc
+++ b/meta/recipes-devtools/gcc/gcc-7.2.inc
@@ -74,6 +74,7 @@ SRC_URI = "\
            file://0047-sync-gcc-stddef.h-with-musl.patch \
            file://0048-gcc-Enable-static-PIE.patch \
            file://fix-segmentation-fault-precompiled-hdr.patch \
+           file://fix-internal-compiler-error-with-includes.patch \
            ${BACKPORTS} \
 "
 BACKPORTS = "\

--- a/meta/recipes-devtools/gcc/gcc-7.2/fix-internal-compiler-error-with-includes.patch
+++ b/meta/recipes-devtools/gcc/gcc-7.2/fix-internal-compiler-error-with-includes.patch
@@ -1,0 +1,27 @@
+In some cases a subregister can be reloaded in an incorrect mode leading
+to junk data being loaded beyond the true width of the reload value.
+---
+ gcc/lra-constraints.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/lra-constraints.c b/gcc/lra-constraints.c
+index 77bb139..316ac86 100644
+--- a/gcc/lra-constraints.c
++++ b/gcc/lra-constraints.c
+@@ -4010,7 +4010,12 @@ curr_insn_transform (bool check_only_p)
+ 			  && (goal_alt[i] == NO_REGS
+ 			      || (simplify_subreg_regno
+ 				  (ira_class_hard_regs[goal_alt[i]][0],
+-				   GET_MODE (reg), byte, mode) >= 0)))))
++				   GET_MODE (reg), byte, mode) >= 0)))
++		      || (type != OP_IN
++			  && (GET_MODE_PRECISION (mode)
++			      < GET_MODE_PRECISION (GET_MODE (reg)))
++			  && GET_MODE_SIZE (GET_MODE (reg)) <= UNITS_PER_WORD
++			  && WORD_REGISTER_OPERATIONS)))
+ 		{
+ 		  /* An OP_INOUT is required when reloading a subreg of a
+ 		     mode wider than a word to ensure that data beyond the
+-- 
+2.2.1
+


### PR DESCRIPTION
Fixes #23. Added a patch to gcc-7.2 to fix an internal compiler error when compiling simple programs such as a hello world program. Patch found here: https://github.com/riscv/riscv-gcc/issues/100#issuecomment-357400823.